### PR TITLE
Update Packer artifact nesting

### DIFF
--- a/fixtures/multiple-runs-single-region.grapl-artifacts.json
+++ b/fixtures/multiple-runs-single-region.grapl-artifacts.json
@@ -1,3 +1,5 @@
 {
-    "multiple-runs-single-region.us-east-1": "ami-aaaaaaaaaaaaaaaaa"
+    "multiple-runs-single-region": {
+        "us-east-1": "ami-aaaaaaaaaaaaaaaaa"
+    }
 }

--- a/fixtures/single-run-multiple-regions.grapl-artifacts.json
+++ b/fixtures/single-run-multiple-regions.grapl-artifacts.json
@@ -1,6 +1,8 @@
 {
-  "single-run-multiple-regions.us-east-1": "ami-aaaaaaaaaaaaaaaaa",
-  "single-run-multiple-regions.us-east-2": "ami-bbbbbbbbbbbbbbbbb",
-  "single-run-multiple-regions.us-west-1": "ami-ccccccccccccccccc",
-  "single-run-multiple-regions.us-west-2": "ami-ddddddddddddddddd"
+    "single-run-multiple-regions": {
+        "us-east-1": "ami-aaaaaaaaaaaaaaaaa",
+        "us-east-2": "ami-bbbbbbbbbbbbbbbbb",
+        "us-west-1": "ami-ccccccccccccccccc",
+        "us-west-2": "ami-ddddddddddddddddd"
+    }
 }

--- a/fixtures/single-run-single-region.grapl-artifacts.json
+++ b/fixtures/single-run-single-region.grapl-artifacts.json
@@ -1,3 +1,5 @@
 {
-    "single-run-single-region.us-east-1": "ami-aaaaaaaaaaaaaaaaa"
+    "single-run-single-region": {
+        "us-east-1": "ami-aaaaaaaaaaaaaaaaa"
+    }
 }

--- a/lib/extract_ami_id_dict.jq
+++ b/lib/extract_ami_id_dict.jq
@@ -12,10 +12,8 @@
 | map(split(":"))
 
 # sample output:
-# { "imgname.us-east-1": "ami-111", ...}
+# { "imgname": {"us-east-1": "ami-111"}}
 | reduce .[] as $region_and_ami_id(
     {};  # becomes the self - or `.` in below context
-    # We use a period delimiter in the key so that, much later down the pipeline,
-    # we can shove it into `pulumi config set --path artifacts.imagename.region`
-    .[$IMAGE_NAME + "." + $region_and_ami_id[0]] = $region_and_ami_id[1]  # {[k] = v}
+    setpath([$IMAGE_NAME, $region_and_ami_id[0]]; $region_and_ami_id[1])
 )


### PR DESCRIPTION
This is to maintain compatibility with the `grapl-rc` plugin which
changed it's nesting logic with
https://github.com/grapl-security/grapl-rc-buildkite-plugin/pull/19

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
